### PR TITLE
[fix] change derivation path mode to HDW_ED25519_SLIP10

### DIFF
--- a/app/src/crypto.c
+++ b/app/src/crypto.c
@@ -34,7 +34,7 @@ zxerr_t crypto_extractPublicKey(uint8_t *pubKey, uint16_t pubKeyLen) {
     zxerr_t err = zxerr_unknown;
     // Generate keys
     CATCH_CXERROR(os_derive_bip32_with_seed_no_throw(
-        HDW_NORMAL,
+        HDW_ED25519_SLIP10,
         CX_CURVE_Ed25519,
         hdPath.path,
         hdPath.pathLength,
@@ -71,7 +71,7 @@ zxerr_t crypto_sign(uint8_t *signature, uint16_t signatureMaxlen, const uint8_t 
     zxerr_t err = zxerr_unknown;
     // Generate keys
     CATCH_CXERROR(os_derive_bip32_with_seed_no_throw(
-        HDW_NORMAL,
+        HDW_ED25519_SLIP10,
         CX_CURVE_Ed25519,
         hdPath.path,
         hdPath.pathLength,


### PR DESCRIPTION
Hello Zondax!

I'm hirish, the dev who made ledger Lisk app v2. 
Lisk devs contacted me because  there is an issue about the derivation path. I've found the issue and this PR fix it.
We have always used curve mode `HDW_ED25519_SLIP10` for the derivation path.  I do not remember exactly why to be honest, it was long time ago.

I've tested it by loading your app + this fix on my development ledger nano S and used Lisk Desktop v3 to check all the accounts I used in the past for testing with ledger. I also made a tx. No problem at all.

![image](https://github.com/Zondax/ledger-lisk/assets/7662810/45c9e051-20d1-4f08-b226-f0bfcdbb2e5e)

I will let you fix all the tests and everything related to QA.

I want to take the opportunity to tell you I'm really impressed by your tools (zemu, ecc..) and the dev environment you have created. Really an awesome job. Top class development.

Best,

hirish